### PR TITLE
Adding MIT license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ $ runn cu
 
 ### License
 
-MIT
+[MIT](https://github.com/99xt/runn/blob/master/LICENSE)


### PR DESCRIPTION
Fix #7 
I have added a link to MIT licence in the README.md 